### PR TITLE
Add a minimal example of web service

### DIFF
--- a/example/web/deployment.ts
+++ b/example/web/deployment.ts
@@ -1,0 +1,35 @@
+import { Deployment, env } from "./deps.ts";
+import labels from "./labels.ts";
+
+const replicas = {
+  staging: 1,
+  production: 2,
+};
+
+const name = labels.app;
+const image = "nginx:1.7.9";
+
+const res: Deployment = {
+  apiVersion: "apps/v1",
+  kind: "Deployment",
+  metadata: {
+    name,
+    labels,
+  },
+  spec: {
+    selector: { matchLabels: labels },
+    replicas: replicas[env],
+    template: {
+      metadata: { labels },
+      spec: {
+        containers: [{
+          name: "nginx",
+          image: image,
+          ports: [{ containerPort: 80 }],
+        }],
+      },
+    },
+  },
+};
+
+export default res;

--- a/example/web/deps.ts
+++ b/example/web/deps.ts
@@ -1,0 +1,1 @@
+export * from "https://deno.land/x/kube_script@v0.2.0/mod.ts";

--- a/example/web/ks
+++ b/example/web/ks
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec deno run --unstable --allow-net --allow-env --allow-read 'https://cdn.jsdelivr.net/gh/in-fun/kube-script/main.ts' "$@"

--- a/example/web/labels.ts
+++ b/example/web/labels.ts
@@ -1,0 +1,1 @@
+export default { app: "web" };

--- a/example/web/mod.ts
+++ b/example/web/mod.ts
@@ -1,0 +1,7 @@
+import deployment from "./deployment.ts";
+import service from "./service.ts";
+
+export default [
+  deployment,
+  service,
+];

--- a/example/web/readme.md
+++ b/example/web/readme.md
@@ -1,0 +1,22 @@
+## A minimal web service example
+
+### Deployment
+1. Preview the resources.
+    ```bash
+    ks example/web
+    ```
+1. View the differences.
+    ```bash
+    ks example/web | k -f - diff
+    ```
+1. Apply the changes.
+    ```bash
+    ks example/web | k -f - apply
+    ```
+
+### Test
+1. Port forward to the k8s.
+    ```bash
+    k port-forward service/web 8080:80
+    ```
+1. Connect to the service by opening [this link](http://localhost:8080/).

--- a/example/web/service.ts
+++ b/example/web/service.ts
@@ -1,0 +1,20 @@
+import { Service } from "./deps.ts";
+import labels from "./labels.ts";
+
+const name = labels.app;
+const res: Service = {
+  apiVersion: "v1",
+  kind: "Service",
+  metadata: {
+    name,
+  },
+  spec: {
+    clusterIP: "None",
+    selector: labels,
+    ports: [
+      { port: 80 },
+    ],
+  },
+};
+
+export default res;

--- a/readme.md
+++ b/readme.md
@@ -2,7 +2,7 @@
 <p align="center">
 <img width="256" alt="cover" src="doc/image/cover_photo.png"/>
 
-**`KubeScript` is a *infrastructure as code* solution to Kubernete devops**
+**`KubeScript` is a DRY *infrastructure as code* solution to Kubernetes DevOps**
 
 <img width="400" alt="demo" src="doc/image/service.ts.png"/>
 </p>
@@ -17,7 +17,8 @@
 ### Features
 
 * [No yaml files](https://noyaml.com/).
-* Type safe with Typescript.
+* No boilerplate or hack.
+* Type based code completion with Typescript.
 * Safe sandbox with Deno.
 
 ## Quickstart
@@ -35,7 +36,7 @@
 
 You can try `KubeScript` without writing any code.
 ```bash
-ks https://deno.land/x/kube_script/example/nginx/mod.ts
+ks https://deno.land/x/kube_script/example/web/mod.ts
 ```
 
 ### Deploy Nginx


### PR DESCRIPTION
The current `nginx` example requires local directory access since version `0.2.0`, so the usage as documented in the `readme.md` does not work.

```shell
ks https://deno.land/x/kube_script/example/nginx/mod.ts
```

To fix the issue, a new minimal example is added.